### PR TITLE
FIX: Parsing .md docs file compiles

### DIFF
--- a/src/routes/docs/index.json.js
+++ b/src/routes/docs/index.json.js
@@ -11,20 +11,20 @@ export function get() {
 				const filename = `${dir}/${key}/index.svelte.md`;
 				if (!fs.existsSync(filename)) return null;
 
-				let match = /---\n([\s\S]+?)\n---\n([\s\S]+)/.exec(fs.readFileSync(filename, 'utf-8'));
-
-				if (!match) {
+				let match_list = fs.readFileSync(filename, 'utf-8').split("---")
+				// first is before first --- line, which is blank
+				if (match_list.length != 3) {
 					throw new Error(`${key} missing frontmatter`);
 				}
-
-				const [, frontmatter, content] = match;
+				const [, frontmatter, content] = match_list;
 
 				/** @type {Record<string, string>} */
 				const metadata = {};
-
 				frontmatter.split('\n').forEach((line) => {
-					const [key, value] = line.split(':');
-					metadata[key.trim()] = value.trim();
+					if (line.includes(":")) {
+						const [key, value] = line.split(':');
+						metadata[key.trim()] = value.trim();
+					}
 				});
 
 				const path = `/docs/${key.slice(3)}`;
@@ -35,10 +35,10 @@ export function get() {
 				const slugify = make_session_slug_processor();
 
 				const pattern = /^##(#)? *(.+)/gm;
-				while ((match = pattern.exec(content))) {
-					const title = match[2].trim();
+				while ((match_list = pattern.exec(content))) {
+					const title = match_list[2].trim();
 
-					if (match[1]) {
+					if (match_list[1]) {
 						// subsection
 						if (!current) throw new Error(`encountered h3 before h2`);
 						current.sections.push({


### PR DESCRIPTION
### Summary
For some reason, I was getting a formatting error when building and previewing the docs.
Looked into the parsing, and got it working by replacing the regex with just a line split.
I was working on windows, so maybe its a file read utf-8 issue...?

### Traceback
```js
Error: 01-getting-started missing frontmatter
    at file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/index.json-905369c5.js:21:15
    at Array.map (<anonymous>)
    at get (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/index.json-905369c5.js:15:31)
    at render_endpoint (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:94:26)
    at async resolve (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:1257:56)
    at async respond (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:1240:12)
    at async fetch (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:736:28)
    at async load (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/__layout-69fd640b.js:58:20)
    at async load_node (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:819:14)
    at async respond$1 (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:941:22)
SyntaxError: Unexpected number in JSON at position 1
    at JSON.parse (<anonymous>)
    at Proxy.<anonymous> (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:801:31)
    at async load (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/__layout-69fd640b.js:58:20)
    at async load_node (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:819:14)
    at async respond$1 (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:941:22)
    at async render_page (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:1070:20)
    at async resolve (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:1257:104)
    at async respond (file:///E:/coding/svelte-cubed/.svelte-kit/output/server/chunks/app-6dccf0a2.js:1240:12)
    at async visit (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:167:20)
    at async visit (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:293:6)
> 500 /docs/getting-started (linked from /)
Error: 500 /docs/getting-started (linked from /)
    at file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:86:11
    at visit (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:222:5)
    at async visit (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:293:6)
    at async prerender (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:303:6)
    at async Object.prerender (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:368:4)
    at async adapt (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+adapter-static@1.0.0-next.21/node_modules/@sveltejs/adapter-static/index.js:13:4)
    at async adapt (file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/chunks/index4.js:393:2)
    at async file:///E:/coding/svelte-cubed/node_modules/.pnpm/@sveltejs+kit@1.0.0-next.201_svelte@3.44.1/node_modules/@sveltejs/kit/dist/cli.js:896:5
 ELIFECYCLE  Command failed with exit code 1.
```
